### PR TITLE
feat: add disk cleanup systemd timers for Docker and Rust

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -154,6 +154,38 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 	type -p fish
 
 RUN <<EOF
+set -euxo pipefail
+echo "**** Install Docker cleanup timer ****"
+
+cat <<- '_DOC_' > /etc/systemd/system/docker-cleanup.service
+[Unit]
+Description=Docker system cleanup (prune unused images and build cache)
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/docker system prune --all --force
+_DOC_
+
+cat <<- '_DOC_' > /etc/systemd/system/docker-cleanup.timer
+[Unit]
+Description=Docker system cleanup (every 6 hours)
+
+[Timer]
+OnCalendar=*-*-* 0/6:00:00
+Persistent=true
+RandomizedDelaySec=1h
+
+[Install]
+WantedBy=timers.target
+_DOC_
+
+systemctl enable docker-cleanup.timer
+
+EOF
+
+RUN <<EOF
 echo "**** systemctl mask gpg-agent* ****"
 set -euxo pipefail
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ WSL2 の開発環境を自動構築するセット\
 | mise Tools                                               | Latest release                                                            | Latest commit                                                                           |
 | :------------------------------------------------------- | :------------------------------------------------------------------------ | :-------------------------------------------------------------------------------------- |
 | [aws-cli](https://github.com/aws/aws-cli/)               | ![GitHub Tag](https://img.shields.io/github/v/tag/aws/aws-cli)            | ![GitHub last commit](https://img.shields.io/github/last-commit/aws/aws-cli)            |
-| [aws-sam-cli](https://github.com/aws/aws-sam-cli)        | ![GitHub Tag](https://img.shields.io/github/v/tag/aws/aws-sam-cli)        | ![GitHub last commit](https://img.shields.io/github/last-commit/aws/aws-sam-cli)        |
 | [claude-code](https://github.com/anthropics/claude-code) | ![GitHub Tag](https://img.shields.io/github/v/tag/anthropics/claude-code) | ![GitHub last commit](https://img.shields.io/github/last-commit/anthropics/claude-code) |
 | [dprint](https://github.com/dprint/dprint)               | ![GitHub Tag](https://img.shields.io/github/v/tag/dprint/dprint)          | ![GitHub last commit](https://img.shields.io/github/last-commit/dprint/dprint)          |
 | [dua-cli](https://github.com/Byron/dua-cli)              | ![GitHub Tag](https://img.shields.io/github/v/tag/Byron/dua-cli)          | ![GitHub last commit](https://img.shields.io/github/last-commit/Byron/dua-cli)          |
@@ -48,7 +47,7 @@ Ref: [Registry | mise-en-place](https://mise.jdx.dev/registry.html?filter=usage#
 
 > [!TIP]
 > **Windows 11 の .ssh/config 例**
-> 
+>
 > Remote SSH 先の uid (`id -u` の結果)が 1000 の場合下記を設定します
 >
 > ```text
@@ -62,7 +61,7 @@ Ref: [Registry | mise-en-place](https://mise.jdx.dev/registry.html?filter=usage#
 
 > [!TIP]
 > **Remote SSH 先のセットアップ**
-> 
+>
 > Remote 先でも gpg-agent の設定が必要です。 setup.sh にまとめてあるためこれを実行します。
 > このスクリプトは以下を実行します:
 >
@@ -169,8 +168,7 @@ wsl --unregister dwsl2-8718ff1
 
 ### Fish ではなく Bash を起動する場合
 
-デフォルトではユーザーフレンドリーのために `login shell` -> `~/.bashrc` -> `exec fish` のような起動順序で fish shell が立ち上がります。が、 POSIX 準拠 SHELL ではないため GenAI などで生成したスクリプトは上手く機能しない可能性があります。その場合 Bash を起動するには、下記の方法を用意しています。`NO_FISH` 変数が定義済みの場合 `~/.bashrc` で `exec fish` を実行しないようにしている。  
-
+デフォルトではユーザーフレンドリーのために `login shell` -> `~/.bashrc` -> `exec fish` のような起動順序で fish shell が立ち上がります。が、 POSIX 準拠 SHELL ではないため GenAI などで生成したスクリプトは上手く機能しない可能性があります。その場合 Bash を起動するには、下記の方法を用意しています。`NO_FISH` 変数が定義済みの場合 `~/.bashrc` で `exec fish` を実行しないようにしている。
 
 ```powershell
 # デフォルト WSL2 にしている場合
@@ -178,7 +176,6 @@ wsl NO_FISH=true bash -l
 
 # ディストリビューションを指定する場合
 wsl -d dwsl2-8718ff1 NO_FISH=true bash -l
-
 ```
 
 > [!TIP]
@@ -191,5 +188,4 @@ wsl -d dwsl2-8718ff1 NO_FISH=true bash -l
 > if [[ ! -v REMOTE_CONTAINERS_IPC ]] && [[ -z "$NO_FISH" ]] && command -v fish &> /dev/null; then
 >     exec fish --login
 > fi
-> 
 > ```

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
+"cargo:cargo-sweep" = "latest"
 "cargo:topgrade" = "latest"
-aws-sam-cli = { version = "latest", symlink_bins = "true" }
 awscli = { version = "latest", symlink_bins = "true" }
 chezmoi = "latest"
 dprint = "latest"

--- a/scripts/bin/setup.sh
+++ b/scripts/bin/setup.sh
@@ -730,6 +730,65 @@ EOF
 	fi
 }
 
+install_cargo_sweep_timer_wsl2() {
+	local systemd_dst="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+	local needs_reload=false
+
+	log_info "Installing cargo-sweep systemd user timer..."
+
+	local cargo_sweep_service_content
+	cargo_sweep_service_content="$(cat << 'UNIT_EOF'
+[Unit]
+Description=Cargo sweep (remove build artifacts older than 1 day)
+
+[Service]
+Type=oneshot
+ExecStart=%h/.local/share/mise/shims/cargo-sweep --time 1 --recursive %h/gits
+UNIT_EOF
+)"
+	if write_if_changed "${systemd_dst}/cargo-sweep.service" "${cargo_sweep_service_content}"; then
+		log_info "Updated: ${systemd_dst}/cargo-sweep.service"
+		needs_reload=true
+	else
+		log_info "Unchanged: ${systemd_dst}/cargo-sweep.service"
+	fi
+
+	local cargo_sweep_timer_content
+	cargo_sweep_timer_content="$(cat << 'UNIT_EOF'
+[Unit]
+Description=Cargo sweep (every 6 hours)
+
+[Timer]
+OnCalendar=*-*-* 0/6:00:00
+Persistent=true
+RandomizedDelaySec=30min
+
+[Install]
+WantedBy=timers.target
+UNIT_EOF
+)"
+	if write_if_changed "${systemd_dst}/cargo-sweep.timer" "${cargo_sweep_timer_content}"; then
+		log_info "Updated: ${systemd_dst}/cargo-sweep.timer"
+		needs_reload=true
+	else
+		log_info "Unchanged: ${systemd_dst}/cargo-sweep.timer"
+	fi
+
+	if [ "${needs_reload}" = true ]; then
+		systemctl --user daemon-reload
+		log_info "systemd: daemon-reload"
+	fi
+
+	if ! systemctl --user is-active --quiet cargo-sweep.timer; then
+		systemctl --user enable --now cargo-sweep.timer
+		log_info "cargo-sweep.timer: enabled"
+	else
+		log_info "cargo-sweep.timer: already active"
+	fi
+
+	log_info "cargo-sweep timer: installed"
+}
+
 # -----------------------------------------------------------------------------
 # Main
 # -----------------------------------------------------------------------------
@@ -752,6 +811,7 @@ main_wsl2() {
 	install_systemd_units_wsl2
 	install_shell_config_wsl2
 	install_vscode_server_env_wsl2
+	install_cargo_sweep_timer_wsl2
 
 	# Create lock file
 	mkdir -p "$(dirname "${LOCK_FILE}")"


### PR DESCRIPTION
## 概要

- WSL2 の 100GB ディスク制限で Docker キャッシュ・未使用イメージが蓄積し disk full になる問題に対応
- Rust プロジェクトの `target/` ディレクトリ肥大化に対応するため cargo-sweep を導入
- Dockerfile に docker-cleanup systemd timer を追加（6時間ごとに `docker system prune --all --force`）
- setup.sh に cargo-sweep systemd user timer を追加（6時間ごとに 1日以上未使用のビルド成果物を削除）
- mise.toml に `cargo:cargo-sweep` を追加し、不要になった `aws-sam-cli` を削除

## テスト計画

- [x] `mise run pre-commit` が成功（dprint fmt + docker build）
- [x] Dockerfile ビルドが成功
- [ ] WSL2 環境で `setup.sh` を実行し cargo-sweep timer が有効化されることを確認
- [ ] `systemctl list-timers --all` で `docker-cleanup.timer` が表示されることを確認
- [ ] `systemctl --user list-timers --all` で `cargo-sweep.timer` が表示されることを確認