### PR TITLE
feat(setup): move docker-cleanup timer and bashrc loader to setup.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -154,51 +154,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 	type -p fish
 
 RUN <<EOF
-set -euxo pipefail
-echo "**** Install Docker cleanup timer ****"
-
-cat <<- '_DOC_' > /etc/systemd/system/docker-cleanup.service
-[Unit]
-Description=Docker system cleanup (prune unused images and build cache)
-Requires=docker.service
-After=docker.service
-
-[Service]
-Type=oneshot
-ExecStart=/usr/bin/docker system prune --all --force
-_DOC_
-
-cat <<- '_DOC_' > /etc/systemd/system/docker-cleanup.timer
-[Unit]
-Description=Docker system cleanup (every 6 hours)
-
-[Timer]
-OnCalendar=*-*-* 0/6:00:00
-Persistent=true
-RandomizedDelaySec=1h
-
-[Install]
-WantedBy=timers.target
-_DOC_
-
-systemctl enable docker-cleanup.timer
-
-EOF
-
-RUN <<EOF
-echo "**** systemctl mask gpg-agent* ****"
-set -euxo pipefail
-
-mkdir -p /etc/systemd/user
-ln -sf /dev/null /etc/systemd/user/gpg-agent.socket
-ln -sf /dev/null /etc/systemd/user/gpg-agent-browser.socket
-ln -sf /dev/null /etc/systemd/user/gpg-agent-extra.socket
-ln -sf /dev/null /etc/systemd/user/gpg-agent-ssh.socket
-ln -sf /dev/null /etc/systemd/user/gpg-agent.service
-
-EOF
-
-RUN <<EOF
 echo "**** Add /etc/devtool-release ****"
 set -euxo pipefail
 
@@ -264,7 +219,7 @@ fi
 # Switch to fish for interactive
 # Note: REMOTE_CONTAINERS_IPC is set during Dev Containers userEnvProbe (undocumented)
 if [[ ! -v REMOTE_CONTAINERS_IPC ]] && [[ -z "$NO_FISH" ]] && command -v fish &> /dev/null; then
-    exec fish --login
+	exec fish --login
 fi
 
 _DOC_

--- a/README.md
+++ b/README.md
@@ -186,6 +186,6 @@ wsl -d dwsl2-8718ff1 NO_FISH=true bash -l
 > # Switch to fish for interactive
 > # Note: REMOTE_CONTAINERS_IPC is set during Dev Containers userEnvProbe (undocumented)
 > if [[ ! -v REMOTE_CONTAINERS_IPC ]] && [[ -z "$NO_FISH" ]] && command -v fish &> /dev/null; then
->     exec fish --login
+> exec fish --login
 > fi
 > ```

--- a/scripts/bin/setup.sh
+++ b/scripts/bin/setup.sh
@@ -259,6 +259,30 @@ configure_gpg() {
 	fi
 }
 
+install_bashrc_loader() {
+	local bashrc="${HOME}/.bashrc"
+
+	log_info "Installing ~/.bashrc loader..."
+
+	if grep -q 'bashrc\.d' "${bashrc}" 2>/dev/null; then
+		log_info "${bashrc}: already has bashrc.d loader"
+		return
+	fi
+
+	log_info "Adding bashrc.d loader to ${bashrc}..."
+	cat >> "${bashrc}" << 'EOF'
+
+# Include ~/.bashrc.d/ when using login shell
+if [ -d ~/.bashrc.d ]; then
+	for script in ~/.bashrc.d/*.sh; do
+		[ -r "$script" ] && . "$script"
+	done
+	unset script
+fi
+EOF
+	log_info "Updated: ${bashrc}"
+}
+
 install_systemd_units_wsl2() {
 	local systemd_dst="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
 	local needs_reload=false
@@ -507,25 +531,7 @@ SHELL_EOF
 		log_info "Unchanged: ${bashrc_d}/21-ssh-agent.sh"
 	fi
 
-	# Check if .bashrc sources ~/.bashrc.d/*.sh
-	if ! grep -q 'bashrc\.d' "${bashrc}" 2>/dev/null; then
-		log_info "Adding ${bashrc_d} loader to ${bashrc}..."
-		# shellcheck disable=SC2016
-		cat >> "${bashrc}" << 'EOF'
-
-# Include ~/.bashrc.d/*.sh
-if [ -d "$HOME/.bashrc.d" ]; then
-    for script in "$HOME/.bashrc.d"/*.sh; do
-        # shellcheck source=/dev/null
-        [ -r "$script" ] && . "$script"
-    done
-    unset script
-fi
-EOF
-		log_info "Updated: ${bashrc}"
-	else
-		log_info "${bashrc}: already sources ${bashrc_d}"
-	fi
+	install_bashrc_loader
 }
 
 install_shell_config_wsl2() {
@@ -730,6 +736,67 @@ EOF
 	fi
 }
 
+install_docker_cleanup_timer() {
+	local systemd_dst="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
+	local needs_reload=false
+
+	log_info "Installing docker-cleanup systemd user timer..."
+
+	local docker_cleanup_service_content
+	docker_cleanup_service_content="$(cat << 'UNIT_EOF'
+[Unit]
+Description=Docker system cleanup (prune unused images and build cache)
+Requires=docker.service
+After=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/docker system prune --all --force
+UNIT_EOF
+)"
+	if write_if_changed "${systemd_dst}/docker-cleanup.service" "${docker_cleanup_service_content}"; then
+		log_info "Updated: ${systemd_dst}/docker-cleanup.service"
+		needs_reload=true
+	else
+		log_info "Unchanged: ${systemd_dst}/docker-cleanup.service"
+	fi
+
+	local docker_cleanup_timer_content
+	docker_cleanup_timer_content="$(cat << 'UNIT_EOF'
+[Unit]
+Description=Docker system cleanup (every 6 hours)
+
+[Timer]
+OnCalendar=*-*-* 0/6:00:00
+Persistent=true
+RandomizedDelaySec=1h
+
+[Install]
+WantedBy=timers.target
+UNIT_EOF
+)"
+	if write_if_changed "${systemd_dst}/docker-cleanup.timer" "${docker_cleanup_timer_content}"; then
+		log_info "Updated: ${systemd_dst}/docker-cleanup.timer"
+		needs_reload=true
+	else
+		log_info "Unchanged: ${systemd_dst}/docker-cleanup.timer"
+	fi
+
+	if [ "${needs_reload}" = true ]; then
+		systemctl --user daemon-reload
+		log_info "systemd: daemon-reload"
+	fi
+
+	if ! systemctl --user is-active --quiet docker-cleanup.timer; then
+		systemctl --user enable --now docker-cleanup.timer
+		log_info "docker-cleanup.timer: enabled"
+	else
+		log_info "docker-cleanup.timer: already active"
+	fi
+
+	log_info "docker-cleanup timer: installed"
+}
+
 install_cargo_sweep_timer_wsl2() {
 	local systemd_dst="${XDG_CONFIG_HOME:-$HOME/.config}/systemd/user"
 	local needs_reload=false
@@ -809,8 +876,10 @@ main_wsl2() {
 	install_yubikey_tool
 	configure_gpg
 	install_systemd_units_wsl2
+	install_bashrc_loader
 	install_shell_config_wsl2
 	install_vscode_server_env_wsl2
+	install_docker_cleanup_timer
 	install_cargo_sweep_timer_wsl2
 
 	# Create lock file


### PR DESCRIPTION
## Summary

- `Dockerfile` から docker-cleanup timer / gpg-agent mask の RUN ブロックを削除し、`setup.sh` に移管
- `install_docker_cleanup_timer()` を追加: ユーザーレベル systemd timer (`~/.config/systemd/user/docker-cleanup.{service,timer}`) を初回起動時に作成
- `install_bashrc_loader()` を追加: ベアメタル Ubuntu でも `~/.bashrc.d/*.sh` ローダーを再現可能に（`bashrc.d` grep でべき等）
- `Dockerfile` の bashrc パッチは WSL2 固有の `devtool/*.sh` ループと fish exec のみに整理
- `README.md` の fish exec インデントを修正

## Test plan

- [ ] `docker build .` が成功すること
- [ ] WSL2 初回起動時に `setup.sh` が `install_bashrc_loader` と `install_docker_cleanup_timer` を実行すること
- [ ] `~/.bashrc.d/*.sh` ローダーが `~/.bashrc` に追記されること（重複なし）
- [ ] `docker-cleanup.timer` が `~/.config/systemd/user/` に作成され enable されること