### PR TITLE
fix(ci): force LIBGUESTFS_BACKEND=direct on qcow2 build

### DIFF
--- a/.github/workflows/qcow2.yml
+++ b/.github/workflows/qcow2.yml
@@ -51,14 +51,18 @@ jobs:
 
       - name: Check KVM availability
         run: |
+          # WHY: force direct backend unconditionally. libvirt has no daemon
+          # on GH-hosted runners, and even with KVM present the libguestfs
+          # default networking path (passt) fails on GH runners with
+          # "passt exited with status 1" (nested-virt / netns constraints).
+          # direct backend + QEMU user-net avoids passt entirely; KVM is
+          # still used when /dev/kvm exists.
+          echo "LIBGUESTFS_BACKEND=direct" >> "$GITHUB_ENV"
           if [ -e /dev/kvm ]; then
-            echo "KVM available — using hardware acceleration"
+            echo "KVM available — direct backend with hardware acceleration"
+            sudo chmod 0666 /dev/kvm || true
           else
-            # WHY-NOT: skip LIBGUESTFS_BACKEND here — without it libguestfs
-            # tries libvirt which has no daemon on standard runners and fails.
-            # direct backend lets QEMU use KVM if present, TCG if not.
-            echo "LIBGUESTFS_BACKEND=direct" >> "$GITHUB_ENV"
-            echo "KVM not available — falling back to TCG software emulation"
+            echo "KVM not available — direct backend with TCG software emulation"
           fi
 
       - name: Download Ubuntu noble (24.04 LTS) cloud image


### PR DESCRIPTION
## Summary
- qcow2 build 失敗 (`passt exited with status 1`) 対策。`LIBGUESTFS_BACKEND=direct` を無条件化し、GH-hosted runner の nested-virt 制約で失敗する passt 経路を回避。
- `/dev/kvm` 存在時は `chmod 0666` で非 root libguestfs qemu にアクセス許可、KVM 加速を維持。

## Test plan
- [ ] qcow2 workflow を workflow_dispatch で走らせ、virt-customize step が完走することを確認
- [ ] KVM 有無どちらでも build が成功することを確認 (現行 GH runner は KVM あり)

Ref: PR #421 merge (8318056) 後の追随修正。