### PR TITLE
fix(ci): install passt explicitly and enable libguestfs debug

### DIFF
--- a/.github/workflows/qcow2.yml
+++ b/.github/workflows/qcow2.yml
@@ -44,10 +44,15 @@ jobs:
       - name: Install image build tools
         run: |
           sudo apt-get update
+          # WHY: passt is explicit — libguestfs 1.52+ appliance uses passt for
+          # user-mode net; on ubuntu-24.04 GH runner it is sometimes NOT pulled
+          # transitively via libguestfs-tools, causing "passt exited with
+          # status 1" at appliance boot.
           sudo apt-get install --no-install-recommends --yes \
             libguestfs-tools \
             qemu-utils \
-            cloud-image-utils
+            cloud-image-utils \
+            passt
 
       - name: Check KVM availability
         run: |
@@ -80,6 +85,9 @@ jobs:
           # bootstrap.sh resolves provision_root as
           # PROVISION_ROOT(/opt/devtool) + /scripts/provision — matching
           # the src + "/scripts/provision" logic in bootstrap.sh.
+          # LIBGUESTFS_DEBUG/TRACE surface passt stderr next time this fails
+          export LIBGUESTFS_DEBUG=1
+          export LIBGUESTFS_TRACE=1
           sudo -E virt-customize \
             --add noble-server-cloudimg-amd64.img \
             --mkdir /opt/devtool \


### PR DESCRIPTION
## Summary
- PR #422 の `LIBGUESTFS_BACKEND=direct` fix では passt failure 解消せず。direct backend は qemu launcher の選択で、passt (appliance-level user-mode net) は影響外だった。
- `passt` package を明示 install。ubuntu-24.04 GH runner で libguestfs-tools が passt を transitive install しない事例への対処。
- `LIBGUESTFS_DEBUG=1 LIBGUESTFS_TRACE=1` を虚実解析用に有効化。

## Test plan
- [ ] merge 後の qcow2 workflow run で virt-customize が passt error なしで完走することを確認
- [ ] 万一失敗した場合 DEBUG 出力から passt stderr を確認