### PR TITLE
fix(ci): set passt apparmor profile to complain mode

### DIFF
--- a/.github/workflows/qcow2.yml
+++ b/.github/workflows/qcow2.yml
@@ -52,7 +52,15 @@ jobs:
             libguestfs-tools \
             qemu-utils \
             cloud-image-utils \
-            passt
+            passt \
+            apparmor-utils
+          # WHY: Ubuntu 24.04 ships an AppArmor profile for passt that
+          # denies libguestfs's tmp-scoped invocation, causing passt to
+          # exit status 1 immediately after binding its UNIX socket. Move
+          # the profile to complain mode so libguestfs can spawn passt.
+          if [ -f /etc/apparmor.d/usr.bin.passt ]; then
+            sudo aa-complain /etc/apparmor.d/usr.bin.passt || true
+          fi
 
       - name: Check KVM availability
         run: |


### PR DESCRIPTION
## Summary
- PR #425 の passt package install + DEBUG 有効化により passt が bind 後に status 1 で exit する現象を確認。
- Ubuntu 24.04 の AppArmor profile (`/etc/apparmor.d/usr.bin.passt`) が libguestfs の per-invocation `/tmp` 経路を deny しており、passt の daemonize が失敗。
- `aa-complain` で profile を complain mode に切り替え、enforcement 停止 (log は保持)。

## Test plan
- [ ] qcow2 workflow が virt-customize step を完走することを確認