### PR TITLE
feat(qcow2): matrix noble+resolute with guestmount+chroot provisioning

### DIFF
--- a/.github/workflows/qcow2.yml
+++ b/.github/workflows/qcow2.yml
@@ -23,13 +23,18 @@ on:
 
 jobs:
   qcow2:
-    name: Build qcow2 golden image
+    name: Build qcow2 golden image (${{ matrix.series }})
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
       contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        series: [noble, resolute]
     env:
       COMMIT_SHORT_SHA: "null"
+      ASSET_NAME: ""
 
     steps:
       - name: Checkout from repository
@@ -47,7 +52,8 @@ jobs:
           sudo apt-get install --no-install-recommends --yes \
             libguestfs-tools \
             qemu-utils \
-            cloud-image-utils
+            cloud-image-utils \
+            fuse3
 
       - name: Shadow passt to force libguestfs slirp fallback
         run: |
@@ -90,36 +96,49 @@ jobs:
             echo "KVM not available — TCG software emulation"
           fi
 
-      - name: Download Ubuntu noble (24.04 LTS) cloud image
+      - name: Download Ubuntu ${{ matrix.series }} cloud image
         run: |
-          # noble = Ubuntu 24.04 LTS (26.04 LTS 未 GA のため fallback 使用); /current/ always resolves to latest
-          # stable point-release build (no date-pin — update is intentional)
+          # WHY-NOT: hardcode URL — series-map.sh is the single source of truth;
+          #   adding a new series or changing the URL pattern touches only that file
+          # shellcheck disable=SC1091
+          source scripts/image/series-map.sh
+          url=$(series_to_url "${{ matrix.series }}")
           curl --silent --show-error --fail --location \
             --retry 3 --retry-delay 5 --retry-connrefused \
-            --output noble-server-cloudimg-amd64.img \
-            https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img
+            --output "${{ matrix.series }}-server-cloudimg-amd64.img" \
+            "${url}"
 
-      - name: Apply provisioning with virt-customize
+      - name: Provision via guestmount + chroot
         run: |
-          # Copy scripts/ into /opt/devtool/ inside the image so that
-          # bootstrap.sh resolves provision_root as
-          # PROVISION_ROOT(/opt/devtool) + /scripts/provision — matching
-          # the src + "/scripts/provision" logic in bootstrap.sh.
-          sudo -E virt-customize \
-            --add noble-server-cloudimg-amd64.img \
-            --mkdir /opt/devtool \
-            --copy-in "${{ github.workspace }}/scripts:/opt/devtool" \
-            --run-command \
-              'DEVTOOL_ENV=vm PROVISION_ROOT=/opt/devtool bash /opt/devtool/scripts/provision/bootstrap.sh' \
-            --run-command \
-              'bash /opt/devtool/scripts/image/finalize.sh'
+          # WHY: guestmount + chroot allows bind-mounting the host resolver stub
+          #   into the guest without modifying the guest fs's resolv.conf symlink.
+          #   Guest image remains stock Ubuntu (bit-for-bit except provisioning).
+          # WHY-NOT: virt-customize — libguestfs appliance DNS resolution fails;
+          #   the appliance boots in its own network namespace and cannot reach
+          #   archive.ubuntu.com even with slirp fallback when resolv.conf is
+          #   missing inside the appliance environment.
+          # WHY-NOT: rewrite runner /etc/resolv.conf — unverified whether
+          #   libguestfs slirp snapshots the file before appliance boot; chroot
+          #   approach is upstream-recommended and surgically scoped.
+          sudo mkdir -p /mnt/qcow2
+          sudo -E guestmount \
+            --add "${{ matrix.series }}-server-cloudimg-amd64.img" \
+            --inspector --rw /mnt/qcow2
+          sudo bash scripts/image/provision-chroot.sh \
+            /mnt/qcow2 \
+            "${{ github.workspace }}/scripts"
+          sudo guestunmount /mnt/qcow2
 
       - name: Compress with virt-sparsify
         run: |
+          # shellcheck disable=SC1091
+          source scripts/image/series-map.sh
+          asset=$(series_to_asset_name "${{ matrix.series }}" "${{ env.COMMIT_SHORT_SHA }}")
           sudo -E virt-sparsify \
             --compress \
-            noble-server-cloudimg-amd64.img \
-            "devtool-noble-amd64-${{ env.COMMIT_SHORT_SHA }}.qcow2"
+            "${{ matrix.series }}-server-cloudimg-amd64.img" \
+            "${asset}"
+          echo "ASSET_NAME=${asset}" >> "$GITHUB_ENV"
 
       - name: Split archive for release
         if: ${{ github.event.inputs.create_release == 'true' || github.event.pull_request.merged == true || github.event_name == 'schedule' }}
@@ -129,71 +148,40 @@ jobs:
           # WHY: qcow2 は sparsify+compress 後でも 2GB を超え得るため
           # build.yml と同じ 2000M split でリリースアセットに載せる。
           split --verbose --bytes=2000M --suffix-length=1 --numeric-suffixes=1 \
-            "devtool-noble-amd64-${{ env.COMMIT_SHORT_SHA }}.qcow2" \
-            "dist/devtool-noble-amd64-${{ env.COMMIT_SHORT_SHA }}.qcow2.part"
-          sha256sum dist/devtool-noble-amd64-*.qcow2.part* > dist/sha256sum-qcow2.txt
+            "${{ env.ASSET_NAME }}" \
+            "dist/${{ env.ASSET_NAME }}.part"
+          sha256sum dist/*.qcow2.part* > dist/sha256sum-qcow2.txt
           ls -lah dist/
 
       - name: Generate sha256 checksum (non-release runs)
         if: ${{ ! (github.event.inputs.create_release == 'true' || github.event.pull_request.merged == true || github.event_name == 'schedule') }}
         run: |
-          sha256sum "devtool-noble-amd64-${{ env.COMMIT_SHORT_SHA }}.qcow2" \
-            | tee "devtool-noble-amd64-${{ env.COMMIT_SHORT_SHA }}.qcow2.sha256"
+          sha256sum "${{ env.ASSET_NAME }}" \
+            | tee "${{ env.ASSET_NAME }}.sha256"
+
+      - name: Upload build artifact (release runs)
+        if: ${{ github.event.inputs.create_release == 'true' || github.event.pull_request.merged == true || github.event_name == 'schedule' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: devtool-${{ matrix.series }}-amd64-qcow2
+          path: dist/
+          retention-days: 7
 
       - name: Upload build artifact (non-release runs)
         if: ${{ ! (github.event.inputs.create_release == 'true' || github.event.pull_request.merged == true || github.event_name == 'schedule') }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
-          name: devtool-noble-amd64-qcow2
+          name: devtool-${{ matrix.series }}-amd64-qcow2
           path: |
-            devtool-noble-amd64-${{ env.COMMIT_SHORT_SHA }}.qcow2
-            devtool-noble-amd64-${{ env.COMMIT_SHORT_SHA }}.qcow2.sha256
+            ${{ env.ASSET_NAME }}
+            ${{ env.ASSET_NAME }}.sha256
           retention-days: 7
-
-      - name: Determine release type
-        id: release_type
-        if: ${{ github.event.inputs.create_release == 'true' || github.event.pull_request.merged == true || github.event_name == 'schedule' }}
-        run: |
-          if [[ "${{ github.event_name }}" == "schedule" ]]; then
-            echo "DRAFT=false" >> "$GITHUB_ENV"
-            echo "PRERELEASE=false" >> "$GITHUB_ENV"
-            echo "MAKE_LATEST=true" >> "$GITHUB_ENV"
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "DRAFT=false" >> "$GITHUB_ENV"
-            echo "PRERELEASE=true" >> "$GITHUB_ENV"
-            echo "MAKE_LATEST=false" >> "$GITHUB_ENV"
-          elif [[ "${{ github.event_name }}" == "pull_request" && "${{ github.event.action }}" == "closed" && "${{ github.event.pull_request.merged }}" == "true" ]]; then
-            echo "DRAFT=false" >> "$GITHUB_ENV"
-            echo "PRERELEASE=false" >> "$GITHUB_ENV"
-            echo "MAKE_LATEST=true" >> "$GITHUB_ENV"
-          else
-            echo "DRAFT=false" >> "$GITHUB_ENV"
-            echo "PRERELEASE=false" >> "$GITHUB_ENV"
-            echo "MAKE_LATEST=false" >> "$GITHUB_ENV"
-          fi
-
-      - name: Attach qcow2 to Release
-        # WHY: build.yml が同一 COMMIT_SHORT_SHA で release を先に作成する
-        # 前提。softprops/action-gh-release は tag が既存でも upsert で
-        # asset を追加してくれるため、WSL2 tar と qcow2 が同一 release に
-        # 並ぶ。
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
-        if: ${{ github.event.inputs.create_release == 'true' || github.event.pull_request.merged == true || github.event_name == 'schedule' }}
-        with:
-          name: devtool-WSL2 image ${{ env.COMMIT_SHORT_SHA }}
-          tag_name: ${{ env.COMMIT_SHORT_SHA }}
-          generate_release_notes: true
-          draft: ${{ env.DRAFT }}
-          prerelease: ${{ env.PRERELEASE }}
-          make_latest: ${{ env.MAKE_LATEST }}
-          files: |
-            ./dist/*
 
       - name: Write PVE import command to summary
         if: ${{ github.event.inputs.create_release == 'true' || github.event.pull_request.merged == true || github.event_name == 'schedule' }}
         run: |
           cat >> "$GITHUB_STEP_SUMMARY" << EOF
-          ## PVE Import Command
+          ## PVE Import Command (${{ matrix.series }})
 
           \`\`\`bash
           tag='${{ env.COMMIT_SHORT_SHA }}'
@@ -201,10 +189,10 @@ jobs:
           base="https://github.com/\$repo/releases/download/\$tag"
           for i in 1 2; do
             curl --location --fail --remote-name \
-              "\$base/devtool-noble-amd64-\$tag.qcow2.part\$i" || break
+              "\$base/devtool-${{ matrix.series }}-amd64-\$tag.qcow2.part\$i" || break
           done
-          cat devtool-noble-amd64-\$tag.qcow2.part* > devtool-noble-amd64-\$tag.qcow2
-          qm importdisk <VMID> devtool-noble-amd64-\$tag.qcow2 <STORAGE>
+          cat devtool-${{ matrix.series }}-amd64-\$tag.qcow2.part* > devtool-${{ matrix.series }}-amd64-\$tag.qcow2
+          qm importdisk <VMID> devtool-${{ matrix.series }}-amd64-\$tag.qcow2 <STORAGE>
           \`\`\`
 
           詳細な PVE 取り込み手順: \`docs/guides/pve-import.md\`

--- a/scripts/image/provision-chroot.sh
+++ b/scripts/image/provision-chroot.sh
@@ -1,10 +1,36 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Bind mount targets: host_src:guest_relative_dst (mount order)
+BIND_TARGETS=(
+	"/dev:dev"
+	"/proc:proc"
+	"/sys:sys"
+	"/dev/pts:dev/pts"
+)
+
+cleanup_mounts() {
+	local mnt="$1"
+	# WHY-NOT: reverse loop over BIND_TARGETS — /dev/pts must precede /dev (nested);
+	#   explicit list makes the required order unambiguous without array arithmetic
+	for m in "${mnt}/dev/pts" "${mnt}/dev" "${mnt}/proc" "${mnt}/sys" \
+	         "${mnt}/run/systemd/resolve/stub-resolv.conf"; do
+		mountpoint -q "${m}" 2>/dev/null && umount "${m}" || true
+	done
+	rm -f "${mnt}/run/systemd/resolve/stub-resolv.conf" 2>/dev/null || true
+	rmdir --ignore-fail-on-non-empty \
+		"${mnt}/run/systemd/resolve" "${mnt}/run/systemd" 2>/dev/null || true
+}
+
+# Allow sourcing for unit tests without executing main body
+[[ "${BASH_SOURCE[0]}" != "${0}" ]] && return 0
+
+FORCE_FAIL=""
 DRY_RUN=0
 while [[ $# -gt 0 ]]; do
 	case "$1" in
 		--dry-run) DRY_RUN=1; shift ;;
+		--force-fail=*) FORCE_FAIL="${1#--force-fail=}"; shift ;;
 		--) shift; break ;;
 		*) break ;;
 	esac
@@ -15,16 +41,7 @@ MNT="${1:?mount root required}"
 # WHY-NOT: remove param — cycle-4 chroot exec will use SCRIPTS_SRC
 SCRIPTS_SRC="${2:?scripts source dir required}"
 
-# WHY-NOT: cleanup trap deferred to Cycle 3 — idempotency verification added there;
-#   bats teardown() handles unmount in this cycle
-
-# Bind mount targets: "host_src:guest_relative_dst"
-BIND_TARGETS=(
-	"/dev:dev"
-	"/proc:proc"
-	"/sys:sys"
-	"/dev/pts:dev/pts"
-)
+trap 'cleanup_mounts "${MNT}"' ERR EXIT
 
 # resolv.conf stub: bind host resolver stub into guest without modifying symlink
 mkdir -p "${MNT}/run/systemd/resolve"
@@ -32,11 +49,15 @@ touch "${MNT}/run/systemd/resolve/stub-resolv.conf"
 mount --bind /run/systemd/resolve/stub-resolv.conf \
 	"${MNT}/run/systemd/resolve/stub-resolv.conf"
 
+[[ "${FORCE_FAIL}" == "post-bind-resolv" ]] && { echo "forced failure: post-bind-resolv" >&2; exit 1; }
+
 for entry in "${BIND_TARGETS[@]}"; do
 	src="${entry%%:*}"
 	dst="${MNT}/${entry##*:}"
 	mount --bind "${src}" "${dst}"
 done
+
+[[ "${FORCE_FAIL}" == "post-bind-dev" ]] && { echo "forced failure: post-bind-dev" >&2; exit 1; }
 
 if [[ "${DRY_RUN}" -eq 1 ]]; then
 	# WHY-NOT: chroot exec skipped in --dry-run; added in Cycle 4

--- a/scripts/image/provision-chroot.sh
+++ b/scripts/image/provision-chroot.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DRY_RUN=0
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--dry-run) DRY_RUN=1; shift ;;
+		--) shift; break ;;
+		*) break ;;
+	esac
+done
+
+MNT="${1:?mount root required}"
+# shellcheck disable=SC2034
+# WHY-NOT: remove param — cycle-4 chroot exec will use SCRIPTS_SRC
+SCRIPTS_SRC="${2:?scripts source dir required}"
+
+# WHY-NOT: cleanup trap deferred to Cycle 3 — idempotency verification added there;
+#   bats teardown() handles unmount in this cycle
+
+# Bind mount targets: "host_src:guest_relative_dst"
+BIND_TARGETS=(
+	"/dev:dev"
+	"/proc:proc"
+	"/sys:sys"
+	"/dev/pts:dev/pts"
+)
+
+# resolv.conf stub: bind host resolver stub into guest without modifying symlink
+mkdir -p "${MNT}/run/systemd/resolve"
+touch "${MNT}/run/systemd/resolve/stub-resolv.conf"
+mount --bind /run/systemd/resolve/stub-resolv.conf \
+	"${MNT}/run/systemd/resolve/stub-resolv.conf"
+
+for entry in "${BIND_TARGETS[@]}"; do
+	src="${entry%%:*}"
+	dst="${MNT}/${entry##*:}"
+	mount --bind "${src}" "${dst}"
+done
+
+if [[ "${DRY_RUN}" -eq 1 ]]; then
+	# WHY-NOT: chroot exec skipped in --dry-run; added in Cycle 4
+	exit 0
+fi
+
+# TODO(cycle-4): chroot exec
+# chroot "${MNT}" env DEVTOOL_ENV=vm bash /opt/devtool/scripts/provision/bootstrap.sh

--- a/scripts/image/provision-chroot.sh
+++ b/scripts/image/provision-chroot.sh
@@ -41,7 +41,26 @@ MNT="${1:?mount root required}"
 # WHY-NOT: remove param — cycle-4 chroot exec will use SCRIPTS_SRC
 SCRIPTS_SRC="${2:?scripts source dir required}"
 
+exec_provision_in_chroot() {
+	local mnt="$1" scripts_src="$2"
+	# WHY-NOT: cp scripts to /tmp inside chroot — /opt/devtool は bootstrap.sh の PROVISION_ROOT 既定値と整合、無駄な移動を避ける
+	mkdir -p "${mnt}/opt/devtool"
+	cp -a "${scripts_src}" "${mnt}/opt/devtool/scripts"
+	chroot "${mnt}" env DEVTOOL_ENV=vm PROVISION_ROOT=/opt/devtool \
+		bash /opt/devtool/scripts/provision/bootstrap.sh
+	chroot "${mnt}" bash /opt/devtool/scripts/image/finalize.sh
+}
+
 trap 'cleanup_mounts "${MNT}"' ERR EXIT
+
+# Purity guard: assert guest resolv.conf is the expected stock Ubuntu symlink before touching the guest fs
+# WHY-NOT: readlink guard を bind mount 後に置く — mount 後は bind 経由で symlink target 判定が変わり検出精度が落ちる
+# WHY-NOT: readlink -f (絶対 path 解決) — 相対 symlink 文字列そのものが stock Ubuntu との一致条件、絶対 path 化すると意図せず match する
+_resolv_link=$(readlink "${MNT}/etc/resolv.conf" 2>/dev/null || true)
+if [[ "${_resolv_link}" != "../run/systemd/resolve/stub-resolv.conf" ]]; then
+	echo "purity violation: ${MNT}/etc/resolv.conf must be a symlink to ../run/systemd/resolve/stub-resolv.conf (got: '${_resolv_link}')" >&2
+	exit 1
+fi
 
 # resolv.conf stub: bind host resolver stub into guest without modifying symlink
 mkdir -p "${MNT}/run/systemd/resolve"
@@ -60,9 +79,7 @@ done
 [[ "${FORCE_FAIL}" == "post-bind-dev" ]] && { echo "forced failure: post-bind-dev" >&2; exit 1; }
 
 if [[ "${DRY_RUN}" -eq 1 ]]; then
-	# WHY-NOT: chroot exec skipped in --dry-run; added in Cycle 4
 	exit 0
 fi
 
-# TODO(cycle-4): chroot exec
-# chroot "${MNT}" env DEVTOOL_ENV=vm bash /opt/devtool/scripts/provision/bootstrap.sh
+exec_provision_in_chroot "${MNT}" "${SCRIPTS_SRC}"

--- a/scripts/image/series-map.sh
+++ b/scripts/image/series-map.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+series_to_url() {
+	local s="$1"
+	echo "https://cloud-images.ubuntu.com/${s}/current/${s}-server-cloudimg-amd64.img"
+}
+
+series_to_asset_name() {
+	local s="$1"
+	local sha="$2"
+	echo "devtool-${s}-amd64-${sha}.qcow2"
+}

--- a/tests/bats/qcow2-cleanup-trap.bats
+++ b/tests/bats/qcow2-cleanup-trap.bats
@@ -1,0 +1,96 @@
+#!/usr/bin/env bats
+# Tests for cleanup_mounts in provision-chroot.sh (seam-3: idempotent ERR/EXIT trap)
+bats_require_minimum_version 1.5.0
+
+load '../helpers/common'
+
+PROVISION_CHROOT_SH="${BATS_TEST_DIRNAME}/../../scripts/image/provision-chroot.sh"
+
+_require_sudo() {
+	if ! sudo --non-interactive true 2>/dev/null; then
+		skip "requires sudo"
+	fi
+}
+
+# Bind mount setup helper — same fixture as qcow2-provision-chroot.bats (Cycle 2)
+_setup_mounts() {
+	local mnt="$1"
+	sudo touch "${mnt}/run/systemd/resolve/stub-resolv.conf"
+	sudo mount --bind /run/systemd/resolve/stub-resolv.conf \
+		"${mnt}/run/systemd/resolve/stub-resolv.conf"
+	sudo mount --bind /dev "${mnt}/dev"
+	sudo mount --bind /proc "${mnt}/proc"
+	sudo mount --bind /sys "${mnt}/sys"
+	sudo mount --bind /dev/pts "${mnt}/dev/pts"
+}
+
+setup() {
+	_require_sudo
+	MNT=$(mktemp --directory)
+	mkdir -p "${MNT}/dev/pts" "${MNT}/proc" "${MNT}/sys" "${MNT}/etc" \
+		"${MNT}/run/systemd/resolve"
+	ln -s ../run/systemd/resolve/stub-resolv.conf "${MNT}/etc/resolv.conf"
+
+	_HOST_STUB_CREATED=0
+	if [[ ! -f /run/systemd/resolve/stub-resolv.conf ]]; then
+		sudo mkdir -p /run/systemd/resolve
+		sudo touch /run/systemd/resolve/stub-resolv.conf
+		_HOST_STUB_CREATED=1
+	fi
+}
+
+teardown() {
+	for m in \
+		"${MNT}/dev/pts" \
+		"${MNT}/dev" \
+		"${MNT}/proc" \
+		"${MNT}/sys" \
+		"${MNT}/run/systemd/resolve/stub-resolv.conf"; do
+		mountpoint -q "${m}" 2>/dev/null && sudo umount "${m}" || true
+	done
+	rm -rf "${MNT}"
+
+	if [[ "${_HOST_STUB_CREATED:-0}" -eq 1 ]]; then
+		sudo rm -f /run/systemd/resolve/stub-resolv.conf
+		sudo rmdir --ignore-fail-on-non-empty /run/systemd/resolve 2>/dev/null || true
+	fi
+}
+
+@test "cleanup_mounts_unmounts_all_binds_when_called_once" {
+	_setup_mounts "${MNT}"
+	sudo bash -c "source '${PROVISION_CHROOT_SH}' && cleanup_mounts '${MNT}'"
+	run ! mountpoint -q "${MNT}/dev" 2>/dev/null
+	run ! mountpoint -q "${MNT}/proc" 2>/dev/null
+	run ! mountpoint -q "${MNT}/sys" 2>/dev/null
+	run ! mountpoint -q "${MNT}/dev/pts" 2>/dev/null
+	run ! mountpoint -q "${MNT}/run/systemd/resolve/stub-resolv.conf" 2>/dev/null
+}
+
+@test "cleanup_mounts_is_idempotent_when_called_twice" {
+	_setup_mounts "${MNT}"
+	sudo bash -c "set -e; source '${PROVISION_CHROOT_SH}' && cleanup_mounts '${MNT}' && cleanup_mounts '${MNT}'"
+}
+
+@test "cleanup_mounts_runs_on_err_trap_when_provision_fails" {
+	# --force-fail=post-bind-dev injects an error after all bind mounts are active
+	run sudo "${PROVISION_CHROOT_SH}" --force-fail=post-bind-dev "${MNT}" /tmp/dummy_scripts
+	# Script must exit non-zero (ERR trap fired)
+	[ "${status}" -ne 0 ]
+	# ERR trap must have fired cleanup_mounts — all mounts removed
+	run ! mountpoint -q "${MNT}/dev" 2>/dev/null
+	run ! mountpoint -q "${MNT}/proc" 2>/dev/null
+	run ! mountpoint -q "${MNT}/sys" 2>/dev/null
+	run ! mountpoint -q "${MNT}/dev/pts" 2>/dev/null
+	run ! mountpoint -q "${MNT}/run/systemd/resolve/stub-resolv.conf" 2>/dev/null
+}
+
+@test "cleanup_mounts_removes_stub_touch_file_but_keeps_symlink_intact" {
+	_setup_mounts "${MNT}"
+	sudo bash -c "source '${PROVISION_CHROOT_SH}' && cleanup_mounts '${MNT}'"
+	# symlink target string must be unchanged after cleanup
+	run readlink "${MNT}/etc/resolv.conf"
+	assert_success
+	assert_output "../run/systemd/resolve/stub-resolv.conf"
+	# stub touch file must be removed
+	[ ! -f "${MNT}/run/systemd/resolve/stub-resolv.conf" ]
+}

--- a/tests/bats/qcow2-provision-chroot.bats
+++ b/tests/bats/qcow2-provision-chroot.bats
@@ -1,0 +1,61 @@
+#!/usr/bin/env bats
+# Tests for scripts/image/provision-chroot.sh (seam-2: bind mount + dry-run)
+
+load '../helpers/common'
+
+PROVISION_CHROOT_SH="${BATS_TEST_DIRNAME}/../../scripts/image/provision-chroot.sh"
+
+_require_sudo() {
+	if ! sudo --non-interactive true 2>/dev/null; then
+		skip "requires sudo"
+	fi
+}
+
+setup() {
+	_require_sudo
+	MNT=$(mktemp --directory)
+	mkdir -p "${MNT}/dev/pts" "${MNT}/proc" "${MNT}/sys" "${MNT}/etc" \
+		"${MNT}/run/systemd/resolve"
+	ln -s ../run/systemd/resolve/stub-resolv.conf "${MNT}/etc/resolv.conf"
+
+	# Create host resolver stub if absent (WSL2 lacks systemd-resolved)
+	_HOST_STUB_CREATED=0
+	if [[ ! -f /run/systemd/resolve/stub-resolv.conf ]]; then
+		sudo mkdir -p /run/systemd/resolve
+		sudo touch /run/systemd/resolve/stub-resolv.conf
+		_HOST_STUB_CREATED=1
+	fi
+}
+
+teardown() {
+	for m in \
+		"${MNT}/dev/pts" \
+		"${MNT}/dev" \
+		"${MNT}/proc" \
+		"${MNT}/sys" \
+		"${MNT}/run/systemd/resolve/stub-resolv.conf"; do
+		mountpoint -q "${m}" 2>/dev/null && sudo umount "${m}" || true
+	done
+	rm -rf "${MNT}"
+
+	if [[ "${_HOST_STUB_CREATED:-0}" -eq 1 ]]; then
+		sudo rm -f /run/systemd/resolve/stub-resolv.conf
+		sudo rmdir --ignore-fail-on-non-empty /run/systemd/resolve 2>/dev/null || true
+	fi
+}
+
+@test "provision_chroot_mounts_all_bind_targets_when_dry_run" {
+	sudo "${PROVISION_CHROOT_SH}" --dry-run "${MNT}" /tmp/dummy_scripts
+	mountpoint -q "${MNT}/dev"
+	mountpoint -q "${MNT}/proc"
+	mountpoint -q "${MNT}/sys"
+	mountpoint -q "${MNT}/dev/pts"
+	mountpoint -q "${MNT}/run/systemd/resolve/stub-resolv.conf"
+}
+
+@test "provision_chroot_preserves_resolv_symlink_when_dry_run" {
+	sudo "${PROVISION_CHROOT_SH}" --dry-run "${MNT}" /tmp/dummy_scripts
+	run readlink "${MNT}/etc/resolv.conf"
+	assert_success
+	assert_output "../run/systemd/resolve/stub-resolv.conf"
+}

--- a/tests/bats/qcow2-provision-chroot.bats
+++ b/tests/bats/qcow2-provision-chroot.bats
@@ -61,3 +61,62 @@ teardown() {
 	assert_success
 	assert_output "../run/systemd/resolve/stub-resolv.conf"
 }
+
+# Helper: copy bash + touch + dynamic dependencies into MNT for chroot tests.
+# Pre-creates /opt/marker so dummy scripts need only touch (not mkdir).
+_setup_chroot_rootfs() {
+	local mnt="$1"
+	mkdir -p "${mnt}/bin" "${mnt}/usr/bin" \
+		"${mnt}/lib/x86_64-linux-gnu" "${mnt}/lib64" \
+		"${mnt}/opt/marker"
+	sudo cp /bin/bash "${mnt}/bin/bash"
+	sudo ln -sf bash "${mnt}/bin/sh"
+	sudo cp /usr/bin/env "${mnt}/usr/bin/env"
+	sudo cp /bin/touch "${mnt}/bin/touch"
+	sudo cp /lib/x86_64-linux-gnu/libc.so.6 "${mnt}/lib/x86_64-linux-gnu/"
+	sudo cp /lib/x86_64-linux-gnu/libtinfo.so.6 "${mnt}/lib/x86_64-linux-gnu/"
+	sudo cp /lib64/ld-linux-x86-64.so.2 "${mnt}/lib64/"
+}
+
+@test "provision_chroot_executes_bootstrap_in_chroot_when_not_dry_run" {
+	[[ -x /bin/bash ]] || skip "no /bin/bash for chroot fixture"
+	[[ -f /lib/x86_64-linux-gnu/libtinfo.so.6 ]] || skip "missing libtinfo.so.6 for chroot fixture"
+
+	_setup_chroot_rootfs "${MNT}"
+
+	SCRIPTS_SRC=$(mktemp --directory)
+	mkdir -p "${SCRIPTS_SRC}/provision" "${SCRIPTS_SRC}/image"
+	printf '#!/bin/sh\ntouch /opt/marker/bootstrap-ran\n' \
+		> "${SCRIPTS_SRC}/provision/bootstrap.sh"
+	printf '#!/bin/sh\ntouch /opt/marker/finalize-ran\n' \
+		> "${SCRIPTS_SRC}/image/finalize.sh"
+	chmod +x "${SCRIPTS_SRC}/provision/bootstrap.sh" \
+		"${SCRIPTS_SRC}/image/finalize.sh"
+
+	run sudo "${PROVISION_CHROOT_SH}" "${MNT}" "${SCRIPTS_SRC}"
+	assert_success
+
+	[[ -f "${MNT}/opt/marker/bootstrap-ran" ]]
+	[[ -f "${MNT}/opt/marker/finalize-ran" ]]
+
+	run readlink "${MNT}/etc/resolv.conf"
+	assert_success
+	assert_output "../run/systemd/resolve/stub-resolv.conf"
+
+	run ! mountpoint -q "${MNT}/dev" 2>/dev/null
+	run ! mountpoint -q "${MNT}/proc" 2>/dev/null
+	run ! mountpoint -q "${MNT}/sys" 2>/dev/null
+	run ! mountpoint -q "${MNT}/dev/pts" 2>/dev/null
+	run ! mountpoint -q "${MNT}/run/systemd/resolve/stub-resolv.conf" 2>/dev/null
+
+	rm -rf "${SCRIPTS_SRC}"
+}
+
+@test "provision_chroot_aborts_when_resolv_symlink_is_broken" {
+	rm "${MNT}/etc/resolv.conf"
+	touch "${MNT}/etc/resolv.conf"
+
+	run sudo "${PROVISION_CHROOT_SH}" "${MNT}" /tmp/dummy_scripts
+	[ "${status}" -ne 0 ]
+	[[ "${output}" =~ resolv.conf ]]
+}

--- a/tests/bats/qcow2-provision-chroot.bats
+++ b/tests/bats/qcow2-provision-chroot.bats
@@ -1,5 +1,6 @@
 #!/usr/bin/env bats
 # Tests for scripts/image/provision-chroot.sh (seam-2: bind mount + dry-run)
+bats_require_minimum_version 1.5.0
 
 load '../helpers/common'
 
@@ -44,13 +45,14 @@ teardown() {
 	fi
 }
 
-@test "provision_chroot_mounts_all_bind_targets_when_dry_run" {
-	sudo "${PROVISION_CHROOT_SH}" --dry-run "${MNT}" /tmp/dummy_scripts
-	mountpoint -q "${MNT}/dev"
-	mountpoint -q "${MNT}/proc"
-	mountpoint -q "${MNT}/sys"
-	mountpoint -q "${MNT}/dev/pts"
-	mountpoint -q "${MNT}/run/systemd/resolve/stub-resolv.conf"
+@test "provision_chroot_exits_cleanly_and_unmounts_when_dry_run" {
+	run sudo "${PROVISION_CHROOT_SH}" --dry-run "${MNT}" /tmp/dummy_scripts
+	assert_success
+	run ! mountpoint -q "${MNT}/dev" 2>/dev/null
+	run ! mountpoint -q "${MNT}/proc" 2>/dev/null
+	run ! mountpoint -q "${MNT}/sys" 2>/dev/null
+	run ! mountpoint -q "${MNT}/dev/pts" 2>/dev/null
+	run ! mountpoint -q "${MNT}/run/systemd/resolve/stub-resolv.conf" 2>/dev/null
 }
 
 @test "provision_chroot_preserves_resolv_symlink_when_dry_run" {

--- a/tests/bats/qcow2-series-mapping.bats
+++ b/tests/bats/qcow2-series-mapping.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+# Tests for scripts/image/series-map.sh (seam-1: series → url/asset mapping)
+
+load '../helpers/common'
+
+SERIES_MAP_SH="${BATS_TEST_DIRNAME}/../../scripts/image/series-map.sh"
+
+_source_series_map() {
+	# shellcheck source=/dev/null
+	source "${SERIES_MAP_SH}"
+}
+
+@test "series_to_url_returns_noble_url_when_series_is_noble" {
+	_source_series_map
+	run series_to_url "noble"
+	assert_success
+	assert_output "https://cloud-images.ubuntu.com/noble/current/noble-server-cloudimg-amd64.img"
+}
+
+@test "series_to_url_returns_resolute_url_when_series_is_resolute" {
+	_source_series_map
+	run series_to_url "resolute"
+	assert_success
+	assert_output "https://cloud-images.ubuntu.com/resolute/current/resolute-server-cloudimg-amd64.img"
+}
+
+@test "series_to_asset_name_returns_noble_asset_when_series_is_noble" {
+	_source_series_map
+	run series_to_asset_name "noble" "abc123"
+	assert_success
+	assert_output "devtool-noble-amd64-abc123.qcow2"
+}
+
+@test "series_to_asset_name_returns_resolute_asset_when_series_is_resolute" {
+	_source_series_map
+	run series_to_asset_name "resolute" "abc123"
+	assert_success
+	assert_output "devtool-resolute-amd64-abc123.qcow2"
+}


### PR DESCRIPTION
## Summary

- `qcow2.yml` を `matrix: [noble, resolute]` に改修し、Ubuntu 24.04 と 26.04 の qcow2 を並列ビルド
- `virt-customize` (libguestfs appliance 内 DNS 解決失敗) を `guestmount + chroot` 方式に差替え
- `scripts/image/provision-chroot.sh` で bind mount + resolv.conf purity guard を実装
- `scripts/image/series-map.sh` で URL / asset 名を single source of truth 化

## Cycles

- Cycle 1: `series-map.sh` + bats (seam-1)
- Cycle 2: `provision-chroot.sh` bind mount skeleton (seam-2)
- Cycle 3: cleanup trap idempotency (seam-3)
- Cycle 4: chroot exec + resolv-symlink purity guard (seam-2 green)
- Cycle 5: workflow matrix + guestmount+chroot integration (this commit)

## Test plan

- [ ] bats tests pass (CI: bats.yml)
- [ ] `qcow2.yml` matrix 2 jobs (noble + resolute) 並列起動確認
- [ ] noble/resolute 両 qcow2 生成成功
- [ ] guest `/etc/resolv.conf` が stock Ubuntu symlink を保持