### PR TITLE
fix(qcow2): purge snapd before apt upgrade in vm env

### DIFF
--- a/scripts/provision/system/10-apt-base.sh
+++ b/scripts/provision/system/10-apt-base.sh
@@ -9,6 +9,7 @@ log_erro() { echo -e "\033[0;31m[ERRO]\033[0m $*" >&2; }
 
 TZ="${TZ:-Asia/Tokyo}"
 DRY_RUN="${DRY_RUN:-}"
+DEVTOOL_ENV="${DEVTOOL_ENV:-wsl}"
 
 _apt_get() {
 	if [[ -n "${DRY_RUN}" ]]; then
@@ -43,6 +44,19 @@ done
 # --- apt update / upgrade ---
 log_info "apt update + upgrade"
 _apt_get --yes update
+
+# WHY-NOT: skip purge and let upgrade proceed — snapd 2.75→2.76 postinst
+#   invokes setcap on snap-confine which fails in chroot (no capability
+#   sysfs), aborting the whole apt upgrade with dpkg error. Purging before
+#   upgrade sidesteps the failing package entirely; snapd is unused in the
+#   qcow2 golden image (no snap workloads shipped).
+# WHY-NOT: purge in 40-cleanup-ubuntu.sh — cleanup runs after apt upgrade,
+#   which is exactly the step that fails; must happen before upgrade.
+if [[ "${DEVTOOL_ENV}" == "vm" ]]; then
+	log_info "vm: purge snapd before upgrade (chroot-incompatible postinst)"
+	_apt_get --yes purge snapd
+fi
+
 _apt_get --yes upgrade
 
 # --- unminimize ---


### PR DESCRIPTION
## Summary

- qcow2 build (both noble & resolute) failed post-merge (PR #433) with `dpkg: error processing package snapd (--configure)` during `apt upgrade` in chroot
- Root cause: snapd 2.75→2.76 postinst runs `setcap` on `/usr/lib/snapd/snap-confine` which fails without capability sysfs in the chroot bind-mount set
- Fix: purge snapd before `apt upgrade` when `DEVTOOL_ENV=vm`

Also noted in workflow log but NOT fatal (left untouched by design):

- `cryptsetup: ERROR: Couldn't resolve device /dev/fuse` — cosmetic warning from initramfs cryptsetup hook probing LUKS/ecryptfs; harmless in chroot
- `setpriv: failed to execute /usr/bin/mandb: Permission denied` — cosmetic warning from man-db postinst attempting to drop privileges via setpriv; postinst still exits 0

## Verification

`ubuntu:24.04` privileged container (systemd absent — same conditions as chroot):

- `apt-get purge --yes snapd` → exit 0
- dpkg state → `un`
- `/var/snap`, `/var/lib/snapd`, `/snap` → all removed
- With `ubuntu-minimal` + `ubuntu-standard` installed → no cascading removal (rdeps are Recommends)

Local dry-run: `DEVTOOL_ENV=vm` triggers purge; `DEVTOOL_ENV=wsl` skips.

## Test plan

- [ ] qcow2 (noble) job passes
- [ ] qcow2 (resolute) job passes
- [ ] wsl2 build unchanged (no purge invoked)