### PR TITLE
fix(provision): qcow2 chroot fixes (snapd purge + sudo -u exec)

### DIFF
--- a/scripts/provision/bootstrap.sh
+++ b/scripts/provision/bootstrap.sh
@@ -227,7 +227,15 @@ main() {
 		if [[ -n "${DRY_RUN}" ]]; then
 			log_info "[DRY_RUN] (${DEFAULT_USERNAME}) $*"
 		elif [[ "${EUID}" -eq 0 ]]; then
-			su - "${DEFAULT_USERNAME}" -c "DEVTOOL_ENV='${DEVTOOL_ENV}' DRY_RUN='${DRY_RUN}' PROVISION_ROOT='${provision_root}' bash '$1'"
+			# WHY-NOT: su - user -c — login shell 経由 (${DEFAULT_USERNAME} の
+			#   login shell = /usr/bin/fish) は chroot 内で
+			#   "Permission denied" になり得る (qcow2 resolute で実測)。
+			#   sudo -u -H は login shell を経由せず bash を直接 exec するため
+			#   影響を受けない。phase 2 実装 (bootstrap.sh 内 _phase2_user
+			#   → exec sudo -u user) と経路を統一。
+			sudo --user "${DEFAULT_USERNAME}" --set-home \
+				env "DEVTOOL_ENV=${DEVTOOL_ENV}" "DRY_RUN=${DRY_RUN}" \
+				"PROVISION_ROOT=${provision_root}" bash "$1"
 		else
 			env "DEVTOOL_ENV=${DEVTOOL_ENV}" "DRY_RUN=${DRY_RUN}" "PROVISION_ROOT=${provision_root}" bash "$1"
 		fi

--- a/scripts/provision/system/10-apt-base.sh
+++ b/scripts/provision/system/10-apt-base.sh
@@ -9,6 +9,7 @@ log_erro() { echo -e "\033[0;31m[ERRO]\033[0m $*" >&2; }
 
 TZ="${TZ:-Asia/Tokyo}"
 DRY_RUN="${DRY_RUN:-}"
+DEVTOOL_ENV="${DEVTOOL_ENV:-wsl}"
 
 _apt_get() {
 	if [[ -n "${DRY_RUN}" ]]; then
@@ -43,6 +44,19 @@ done
 # --- apt update / upgrade ---
 log_info "apt update + upgrade"
 _apt_get --yes update
+
+# WHY-NOT: skip purge and let upgrade proceed — snapd 2.75→2.76 postinst
+#   invokes setcap on snap-confine which fails in chroot (no capability
+#   sysfs), aborting the whole apt upgrade with dpkg error. Purging before
+#   upgrade sidesteps the failing package entirely; snapd is unused in the
+#   qcow2 golden image (no snap workloads shipped).
+# WHY-NOT: purge in 40-cleanup-ubuntu.sh — cleanup runs after apt upgrade,
+#   which is exactly the step that fails; must happen before upgrade.
+if [[ "${DEVTOOL_ENV}" == "vm" ]]; then
+	log_info "vm: purge snapd before upgrade (chroot-incompatible postinst)"
+	_apt_get --yes purge snapd
+fi
+
 _apt_get --yes upgrade
 
 # --- unminimize ---


### PR DESCRIPTION
## Summary
- `10-apt-base.sh`: vm 環境限定で apt upgrade 前に snapd を purge。snapd 2.75→2.76 postinst の setcap on snap-confine が chroot で失敗し apt upgrade 全体を落とすため。
- `bootstrap.sh` `_run_as_user`: `su - user -c` → `sudo -u user -H env ... bash`。login shell = fish が chroot 内で Permission denied 発生 (qcow2 resolute 実測)、phase 2 の `exec sudo -u user` と経路統一。

## Test plan
- [ ] qcow2 (noble) build 成功
- [ ] qcow2 (resolute) build 成功
- [ ] Bootstrap Path B (bootstrap.yml) 成功
- [ ] bats 成功